### PR TITLE
Better parameter type checking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,8 @@ Once the spec is more mature, several of these libraries will be forked and alig
 
 1. `tag` must be a string and can't contain extra data like classes or ids (e.g. `div.foo` or `div#bar`)
 2. If the 2nd parameter is defined but the 3rd parameter is not
-    1. And the 2nd is an array or _primitive value_, then it becomes `children`
-    2. And the 2nd is a default javascript object, then it becomes `data`
+    1. And the 2nd is a default javascript object, then it becomes `data`
+    2. And the 2nd is an array or _primitive value_, then it becomes `children`
 3. `data` must be a default javascript object, unless `node` is too. Otherwise it can only be `null` or `undefined`
 4. `children` must be a `node`, _primitive value_, or an array of either
 

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,8 @@ Once the spec is more mature, several of these libraries will be forked and alig
 
 1. `tag` must be a string and can't contain extra data like classes or ids (e.g. `div.foo` or `div#bar`)
 2. If the 2nd parameter is defined but the 3rd parameter is not
-    1. And the 2nd passes step 4, then it becomes `children`
-    2. And the 2nd passes step 3, then it becomes `data`
+    1. And the 2nd is an array or _primitive value_, then it becomes `children`
+    2. And the 2nd is a default javascript object, then it becomes `data`
 3. `data` must be a default javascript object, unless `node` is too. Otherwise it can only be `null` or `undefined`
 4. `children` must be a `node`, _primitive value_, or an array of either
 


### PR DESCRIPTION
Only allows:

```js
h(tag, array(node | primitive))
h(tag, primitive)
```

No longer allowed:

```js
h(tag, node)
```